### PR TITLE
Tweaks to the install script

### DIFF
--- a/jenkins/install_android_toolchain.sh
+++ b/jenkins/install_android_toolchain.sh
@@ -27,8 +27,8 @@ PATH="${CMAKE_DIR}/bin:${PATH}"
 # !!! Workaround for a dumb bug in the AGP
 ln -s "${NINJA_DIR}/bin/ninja" "${CMAKE_DIR}/bin/ninja"
 
-SDK_MGR="${ANDROID_HOME}/cmdline-tools/latest/bin/sdkmanager --channel=1"
+SDK_MGR="${ANDROID_HOME}/cmdline-tools/latest/bin/sdkmanager"
 yes | ${SDK_MGR} --licenses > /dev/null 2>&1
-${SDK_MGR} --install "build-tools;${BUILD_TOOLS_VERSION}"
-${SDK_MGR} --install "ndk;${NDK_VERSION}"
+${SDK_MGR} --channel=1 --install "build-tools;${BUILD_TOOLS_VERSION}"
+${SDK_MGR} --channel=1 --install "ndk;${NDK_VERSION}"
 


### PR DESCRIPTION
On some linux distros quoting the command with channel=1 causes it to not run correctly